### PR TITLE
un test sur un datatype

### DIFF
--- a/input/fsh/CdaIIToIdentifierConceptMap.fsh
+++ b/input/fsh/CdaIIToIdentifierConceptMap.fsh
@@ -1,0 +1,49 @@
+Instance: CdaIIToIdentifierConceptMap
+InstanceOf: ConceptMap
+Usage: #definition
+Title: "ConceptMap — CDA II vers FHIR Identifier"
+Description: "Correspondances entre les éléments du datatype CDA II et les éléments FHIR Identifier."
+
+* url = "https://interop.esante.gouv.fr/ig/fhir/mappingcdafhir/ConceptMap/DataTypes/CdaIIToIdentifier"
+* name = "CdaIIToIdentifier"
+* status = #draft
+* experimental = true
+
+* group[0].source = "http://hl7.org/cda/stds/core/StructureDefinition/II"
+* group[0].target = "http://hl7.org/fhir/StructureDefinition/Identifier"
+
+/* II.extension -> Identifier.value */
+* group[0].element[0].code = #II.extension
+* group[0].element[0].display = "II.extension"
+* group[0].element[0].target[0].code = #Identifier.value
+* group[0].element[0].target[0].display = "Identifier.value"
+* group[0].element[0].target[0].equivalence = #equivalent
+* group[0].element[0].target[0].comment = "Lorsque II.extension est présent, il alimente directement Identifier.value."
+
+/* II.root -> Identifier.system / Identifier.value */
+* group[0].element[1].code = #II.root
+* group[0].element[1].display = "II.root"
+* group[0].element[1].target[0].code = #Identifier.system
+* group[0].element[1].target[0].display = "Identifier.system"
+* group[0].element[1].target[0].equivalence = #relatedto
+* group[0].element[1].target[0].comment = "Utilisé pour alimenter Identifier.system, généralement avec transformation vers un URI."
+
+* group[0].element[1].target[1].code = #Identifier.value
+* group[0].element[1].target[1].display = "Identifier.value"
+* group[0].element[1].target[1].equivalence = #relatedto
+* group[0].element[1].target[1].comment = "En l’absence de II.extension, Identifier.value peut être dérivé de II.root, par exemple sous la forme urn:uuid:[II.root] si II.root est un UUID, ou urn:oid:[II.root] si II.root est un OID."
+
+/* II.assigningAuthorityName -> Identifier.assigner.display */
+* group[0].element[2].code = #II.assigningAuthorityName
+* group[0].element[2].display = "II.assigningAuthorityName"
+* group[0].element[2].target[0].code = #Identifier.assigner.display
+* group[0].element[2].target[0].display = "Identifier.assigner.display"
+* group[0].element[2].target[0].equivalence = #relatedto
+
+/* II.displayable -> Identifier.extension(displayable) */
+* group[0].element[3].code = #II.displayable
+* group[0].element[3].display = "II.displayable"
+* group[0].element[3].target[0].code = #Identifier.extension
+* group[0].element[3].target[0].display = "Identifier.extension(displayable)"
+* group[0].element[3].target[0].equivalence = #relatedto
+* group[0].element[3].target[0].comment = "Porté dans une extension FHIR spécifique."

--- a/input/pagecontent/test.md
+++ b/input/pagecontent/test.md
@@ -1,0 +1,43 @@
+## Mapping entre les datatypes CDA et les datatypes FHIR
+
+{% sql {
+  "query": "
+WITH Mappings AS (
+  SELECT
+    COALESCE(
+      r.name,
+      json_extract(r.json, '$.name')
+    ) AS ConceptMapName,
+    COALESCE(
+      json_extract(e.value, '$.display'),
+      json_extract(e.value, '$.code')
+    ) AS CDA,
+    COALESCE(
+      json_extract(t.value, '$.display'),
+      json_extract(t.value, '$.code')
+    ) AS FHIR,
+    g.key AS group_index,
+    e.key AS elem_index,
+    t.key AS target_index
+  FROM Resources r
+  JOIN json_each(r.json, '$.group') g
+  JOIN json_each(g.value, '$.element') e
+  JOIN json_each(e.value, '$.target') t
+  WHERE r.Type = 'ConceptMap'
+)
+
+SELECT
+  CDA,
+  FHIR
+FROM Mappings
+WHERE ConceptMapName IN (
+  'CdaIIToIdentifier'
+)
+ORDER BY ConceptMapName, group_index, elem_index, target_index
+",
+  "class": "lines",
+  "columns": [
+    { "name": "CDA", "type": "markdown", "source": "CDA" },
+    { "name": "FHIR", "type": "markdown", "source": "FHIR" }
+  ]
+} %}

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -47,6 +47,8 @@ pages:
 
   initiatives-internationales.md:
     title: Initiatives internationales
+  test.md:
+    title: Tableau test 
 
 
 menu:


### PR DESCRIPTION
## Description des changements

* J’ai réalisé un premier test d’aperçu du tableau généré à partir de FSH.
* Dans ce cadre, j’ai créé un ConceptMap FSH pour les identifiants, puis une page test.md qui affiche un tableau généré grâce à une requête SQL parcourant ce ConceptMap.
* L’objectif principal est de pouvoir produire un tableau unique qui parcourt tous les fichiers FSH (ConceptMap) que j’ajouterai par la suite, sur le même principe (si cette approche est validée).
* Une fois ce mécanisme validé, le tableau final généré sera intégré dans la page mapping-mechanisms, dans la section dédiée aux datatypes.
* La page test.md sert uniquement de page de test pour valider le mécanisme ; elle sera supprimée après validation. Ce qui sera réellement fusionné, c’est le tableau final intégré dans mapping mechanisms, pas la page de test.
* Le tableau généré est visible à l’adresse suivante : https://ansforge.github.io/IG-mapping-cda-fhir/test-tableau-datatypes/ig/test.html

## Preview

https://ansforge.github.io/IG-mapping-cda-fhir/test-tableau-datatypes/ig